### PR TITLE
🐛 Fix: 혼자 남으면 초기화

### DIFF
--- a/sky_whale/cog/music_cog.py
+++ b/sky_whale/cog/music_cog.py
@@ -33,15 +33,27 @@ class MusicCog(GroupCog, name="고래"):
     async def on_voice_state_update(
         self, member: Member, before: VoiceState, after: VoiceState
     ) -> None:
-        if member.bot or before.channel is None:
+        if before.channel is None:
             return
-
-        if music := self.bot.musics.get(before.channel.guild.id, None):
+        if music := self.bot.musics.get(member.guild.id, None):
+            # 봇인 경우
+            if member.id == self.bot.user.id:
+                if after.channel is None:
+                    return
+                if (
+                    self.bot.user in after.channel.members
+                    and len([user for user in after.channel.members if not user.bot])
+                    == 0
+                ):
+                    await music.reset()
+                return
+            # 유저인 경우
             if (
                 self.bot.user in before.channel.members
                 and len([user for user in before.channel.members if not user.bot]) == 0
             ):
                 await music.reset()
+                return
 
     @Cog.listener()
     async def on_ready(self) -> None:


### PR DESCRIPTION
음악 재생을 하던 중 사람들이 다 나가면 리소스 절약을 위해 자동으로 초기화 됐습니다.

하지만, 봇이 외딴 채널로 혼자 이동할 경우 초기화되지 않는 버그가 있었습니다.

수정, 했습니다.

close #28 